### PR TITLE
Removed trailing slash from URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Performs a reverse image search using the supplied image URL as input.
 
 ### URL
 
-- *<http://localhost:5000/search/>*
+- POST to *<http://localhost:5000/search>*
 
 ### Arguments
 


### PR DESCRIPTION
Doing a POST to **http://localhost:5000/search/** (with trailing slash) causes a 404.

Changed to **http://localhost:5000/search** (without trailing slash).