### PR TITLE
Add host argument to the command line.

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -175,6 +175,7 @@ def main():
     parser.add_argument('-p', '--port', type=int, default=5000, help='port number')
     parser.add_argument('-d','--debug', action='store_true', help='enable debug mode')
     parser.add_argument('-c','--cors', action='store_true', default=False, help="enable cross-origin requests")
+    parser.add_argument('-a', '--host', type=str, default='0.0.0.0', help="sets the address to serve on")
     args = parser.parse_args()
 
     if args.debug:
@@ -189,7 +190,7 @@ def main():
         print(" * Running with CORS enabled")
 
 
-    app.run(host='0.0.0.0', port=args.port)
+    app.run(host=args.host, port=args.port)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
While I was working on a project of mine that used MRISA as a background service for image search, I noticed that there is no way to actually change the desired address of the server on the machine that the server is running on. The program I am working on will be running on a VPS with full open access to the internet, and I would rather not have the issue of people pinging my MRISA instance while my program needs priority access. Rather than changing just my local instance, I thought that this could be useful to others.