### PR TITLE
Switch Docker to Alpine Linux

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,17 @@
+name: Publish Docker
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: Build Image
+      run: |
+       docker login -u ${{ secrets.USERNAME }} --password ${{ secrets.DOCKER_TOKEN }}
+       docker build -t mrisa:${{ steps.extract_branch.outputs.branch }} .
+       docker tag mrisa:${{ steps.extract_branch.outputs.branch }} ${{ secrets.USERNAME }}/mrisa:${{ steps.extract_branch.outputs.branch }}
+       docker push ${{ secrets.USERNAME }}/mrisa:${{ steps.extract_branch.outputs.branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.7.5-buster
+FROM python:3.7.5-alpine
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
+RUN apk add --update build-base curl-dev openssl-dev curl libxml2-dev libxslt-dev
+RUN pip install -U pip
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./src .


### PR DESCRIPTION
This updates the the Dockerfile changes the distro to Alpine Linux, a distro that is significantly smaller than Debian. The same functionality as all of the same packages are there, just with a smaller image. Here is a comparison of the Alpine Linux image (my [master](https://github.com/chand1012/mrisa/tree/d9a8ab93b36a36f4669cf67e6ff35052a8ad7a28) branch at the time of writing) and the Debian image (vivithemage's [master](https://github.com/vivithemage/mrisa/tree/80404114f44e5b1a1bede1145086915589a25d72) at the time of writing):

```
user@devserv:~$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
chand1012/mrisa     master              cee9fde400dc        About a minute ago   341MB
vivithemage/mrisa   master              5bba371e7885        8 minutes ago        945MB
```

I should mention that switching to Alpine Linux did significantly increase the build time for the Docker Image, as all of the Python Wheels must be rebuilt on Alpine Linux. Here is the output for the `time` command on both of the builds:

vivithemage's [master](https://github.com/vivithemage/mrisa/tree/80404114f44e5b1a1bede1145086915589a25d72):
```
real    1m40.201s
user    0m0.335s
sys     0m0.556s
```

My [master](https://github.com/chand1012/mrisa/tree/d9a8ab93b36a36f4669cf67e6ff35052a8ad7a28):
```
real    4m16.620s
user    0m0.228s
sys     0m0.198s
```

These build times include the time to download all components on a 100Mb/s internet connection on 4 vCores with 8GB of RAM on a Xeon E5-2690 server. 

Also included with this merge would be the YAML file for an Action that would build the Docker Image and publish it to the Docker Hub, provided that you add your Hub username and an Access Token as secrets `USERNAME` and `DOCKER_TOKEN` respectively.